### PR TITLE
Updates for Elm 0.17

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -5,7 +5,7 @@
 <body>
   <script type="text/javascript">
     window.addEventListener("DOMContentLoaded", function (){
-      Elm.fullscreen(Elm.%s, { });
+      Elm.%s.fullscreen({ });
     })
   </script>
 </body>

--- a/src/ElmInit/Types.hs
+++ b/src/ElmInit/Types.hs
@@ -103,7 +103,9 @@ makePackage = ElmPackage
   ⊛ summary
   ⊛ repository
   ⊛ license
-  ⊛ const (object [("elm-lang/core", "3.0.0 <= v < 4.0.0")])
+  ⊛ const (object [ ("elm-lang/core", "4.0.5 <= v < 5.0.0")
+                  , ("elm-lang/html", "1.1.0 <= v < 2.0.0")
+                  ])
   ⊛ const []
   ⊛ elmVersion
   ⊛ (:[]) . pack . sourceFolder


### PR DESCRIPTION
- changed index.html based on [0.17 upgrade doc](https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.17.md#javascript-interop)
- ~~removed redundant imports (stack lts-5.0 comes with base-4.8.2.0 which exports all of those as a part of [prelude](https://www.stackage.org/haddock/lts-5.0/base-4.8.2.0/Prelude.html))~~ EDIT -scratched these as I see you've got CI setup to build with older versions of ghc as well.
- bumped version of `elm-lang/core` and added `elm-lang/html` because that one is always added by `elm make` since 0.17
